### PR TITLE
Update ILiquidationSource implementation

### DIFF
--- a/test/VaultBooster.t.sol
+++ b/test/VaultBooster.t.sol
@@ -11,10 +11,10 @@ import {
   InitialAvailableExceedsBalance,
   OnlyLiquidationPair,
   UnsupportedTokenIn,
-  InsufficientAvailableBalance,
-  FlashSwapNotSupported
+  InsufficientAvailableBalance
 } from "../src/VaultBooster.sol";
 
+import { IFlashSwapCallback } from "pt-v5-liquidator-interfaces/interfaces/IFlashSwapCallback.sol";
 import { PrizePool, TwabController, IERC20 } from "pt-v5-prize-pool/PrizePool.sol";
 
 /// @dev See the "Writing Tests" section in the Foundry Book if this is your first time with Forge.
@@ -292,30 +292,6 @@ contract VaultBoosterTest is Test {
     vm.stopPrank();
   }
 
-  function testLiquidate_FlashSwapNotSupported() public {
-    vm.warp(0);
-    booster.setBoost(boostToken, liquidationPair, UD2x18.wrap(0), 1e18, 0);
-    mockBoostTokenBalance(1e18);
-    vm.warp(10);
-
-    vm.mockCall(
-      address(boostToken),
-      abi.encodeWithSelector(IERC20.transfer.selector, address(this), 1e18),
-      abi.encode(true)
-    );
-
-    vm.mockCall(
-      address(prizePool),
-      abi.encodeWithSelector(prizePool.contributePrizeTokens.selector, vault, 9999e18),
-      abi.encode(9999e18)
-    );
-
-    vm.startPrank(liquidationPair);
-    vm.expectRevert(abi.encodeWithSelector(FlashSwapNotSupported.selector));
-    booster.liquidate(address(this), address(this), address(prizeToken), 9999e18, address(boostToken), 1e18, bytes("flash swap data that is not empty"));
-    vm.stopPrank();
-  }
-
   function testLiquidate_onlyLiquidationPair() public {
     vm.warp(0);
     booster.setBoost(boostToken, liquidationPair, UD2x18.wrap(0), 1e18, 0);
@@ -333,6 +309,44 @@ contract VaultBoosterTest is Test {
   function testTargetOf_unknownToken() public {
     vm.expectRevert(abi.encodeWithSelector(UnsupportedTokenIn.selector));
     booster.targetOf(address(boostToken));
+  }
+
+  function testLiquidate_triggerCallback() public {
+    vm.warp(0);
+    booster.setBoost(boostToken, liquidationPair, UD2x18.wrap(0), 1e18, 0);
+    mockBoostTokenBalance(1e18);
+    vm.warp(10);
+
+    vm.mockCall(
+      address(boostToken),
+      abi.encodeWithSelector(IERC20.transfer.selector, address(this), 1e18),
+      abi.encode(true)
+    );
+
+    vm.mockCall(
+      address(prizePool),
+      abi.encodeWithSelector(prizePool.contributePrizeTokens.selector, vault, 9999e18),
+      abi.encode(9999e18)
+    );
+    
+    address receiver = makeAddr("receiver");
+    vm.mockCallRevert(
+      receiver,
+      abi.encodeWithSelector(
+        IFlashSwapCallback.flashSwapCallback.selector,
+        address(liquidationPair),
+        address(this),
+        9999e18,
+        1e18,
+        abi.encode("testing")
+      ),
+      abi.encodePacked("flash swap callback entered")
+    );
+
+    vm.startPrank(liquidationPair);
+    vm.expectRevert(abi.encodePacked("flash swap callback entered"));
+    booster.liquidate(address(this), receiver, address(prizeToken), 9999e18, address(boostToken), 1e18, abi.encode("testing"));
+    vm.stopPrank();
   }
 
   /** =========== MOCKS ============= */


### PR DESCRIPTION
### Note
`_flashSwapData` was added to the `liquidate` function in the interface, but this contract does not support flash swaps so an error will be thrown if that data is not empty.